### PR TITLE
refactor: use Link in row options

### DIFF
--- a/web/app/admin/rowOptions.tsx
+++ b/web/app/admin/rowOptions.tsx
@@ -12,6 +12,7 @@ import {
 import { createClient } from "@/lib/supabase/client";
 import { MoreHorizontal } from "lucide-react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { toast } from "sonner";
 
 type RowOptionsProps = {
@@ -64,9 +65,9 @@ export default function RowOptions({ rustdeskId }: RowOptionsProps) {
           Connection string
         </DropdownMenuItem>
         <DropdownMenuSeparator />
-        <a href={`/admin/computer/${rustdeskId}`}>
+        <Link href={`/admin/computer/${rustdeskId}`}>
           <DropdownMenuItem>Computer info</DropdownMenuItem>
-        </a>
+        </Link>
         <DropdownMenuSeparator />
         {rustdeskId && (
           <DropdownMenuItem variant="destructive" onClick={handleDelete}>


### PR DESCRIPTION
## Summary
- replace anchor with Next.js Link in admin row options

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0b0a7e508832aa4e7b6aab254f782