### PR TITLE
fix: remove duplicate network dialog cleanup

### DIFF
--- a/web/app/admin/computer/[computerId]/tabs.tsx
+++ b/web/app/admin/computer/[computerId]/tabs.tsx
@@ -329,9 +329,6 @@ function ChangeNetworkStringDialog({
     toast.success("Network was changed");
     setOpen(false);
     form.reset();
-
-    setOpen(false);
-    form.reset();
   }
 
   return (


### PR DESCRIPTION
## Summary
- ensure network string dialog closes and resets form only once after task insert

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0b0791a94832a82dca7f3c910013b