### PR TITLE
Add GitHub workflow to build and push Docker image

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -1,0 +1,51 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/catthehacker/ubuntu:act-latest
+
+    env:
+      IMAGE_NAME: rustdesk-server-webui
+      REGISTRY: git.ondomain.org
+      REPO_OWNER: KiskaLE
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Gitea registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.REPO_OWNER }}
+          password: ${{ secrets.REPO_OWNER_PASSWORD }}
+
+      - name: Read version from package.json
+        id: get_version
+        run: |
+          VERSION=$(jq -r '.version' ./web/package.json)
+          FULL_VERSION="${VERSION}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "FULL_VERSION=$FULL_VERSION" >> $GITHUB_ENV
+          echo "Image version: $FULL_VERSION"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./web
+          file: ./web/Dockerfile
+          target: production
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/kiskale/${{ env.IMAGE_NAME }}:${{ env.FULL_VERSION }}
+            ${{ env.REGISTRY }}/kiskale/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and push Docker image to Gitea registry

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch font `Geist` from Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_68a0c348d7b8832aa662596b103f6059